### PR TITLE
Make the clean_class filter act like Drupal one.

### DIFF
--- a/dist/filters/clean_class.filter.php
+++ b/dist/filters/clean_class.filter.php
@@ -1,5 +1,18 @@
 <?php
 
 $filter = new Twig_SimpleFilter('clean_class', function ($string) {
+  $filters = [
+    ' ' => '-',
+    '_' => '-',
+    '/' => '-',
+    '[' => '-',
+    ']' => '',
+  ];
+  $string = str_replace(array_keys($filters), array_values($filters), $string);
+  $string = preg_replace('/[^\x{002D}\x{0030}-\x{0039}\x{0041}-\x{005A}\x{005F}\x{0061}-\x{007A}\x{00A1}-\x{FFFF}]/u', '', $string);
+  $string = preg_replace([
+    '/^[0-9]/',
+    '/^(-[0-9])|^(--)/'
+  ], ['_', '__'], $string);
   return $string;
 });


### PR DESCRIPTION
I would feel more comfortable using the clean_class filter in my pattern-lab templates if I was confident it would do the same in Pattern Lab as it does in Drupal.