### PR TITLE
Make the Attributes parameter have a default param

### DIFF
--- a/dist/functions/link.function.php
+++ b/dist/functions/link.function.php
@@ -2,7 +2,7 @@
 
 $function = new Twig_SimpleFunction(
     'link',
-    function ($title, $url, $attributes) {
+    function ($title, $url, $attributes = NULL) {
       if (isset($attributes) && isset($attributes['class'])) {
         $classes = join(' ', $attributes['class']);
         return '<a href="' . $url . '" class="' . $classes . '">' . $title . '</a>';


### PR DESCRIPTION
I ran into an issue with this because it was expecting a third parameter, which isn't necessarily necessary.